### PR TITLE
Add support for Flex objects in Grav 1.7

### DIFF
--- a/resize-images.php
+++ b/resize-images.php
@@ -3,6 +3,7 @@ namespace Grav\Plugin;
 
 use Grav\Common\Plugin;
 use Grav\Common\Page\Page;
+use Grav\Common\Flex\Types\Pages\PageObject;
 use RocketTheme\Toolbox\Event\Event;
 
 require_once 'adapters/imagick.php';
@@ -102,7 +103,7 @@ class ResizeImagesPlugin extends Plugin
     {
         $page = $event['object'];
 
-        if (!$page instanceof Page) {
+        if (!($page instanceof Page || $page instanceof PageObject)) {
             return false;
         }
 


### PR DESCRIPTION
This PR resolves #21, and is similar to #22, but retains the check for being a Page (or now PageObject).

I have a few other changes planned (eg. processing on upload rather than save, and a CLI for generating missing images), so I'd be more than happy to take over maintenance of this plugin if you're no longer interested in maintaining it.